### PR TITLE
Fix terminal row wrapping

### DIFF
--- a/kernel/drivers/vga.c
+++ b/kernel/drivers/vga.c
@@ -72,7 +72,7 @@ void putchar(char c, uint8_t COLOR) {
 	}
 	if (terminal_column == VGA_TEXT_WIDTH) {
 		terminal_column = 0;
-		terminal_row = 0;
+		terminal_row++; // MorganPG - Fix implementation for wrapping onto a new line
 	}
 	if (terminal_row == VGA_TEXT_HEIGHT)
 		terminal_row = 0;


### PR DESCRIPTION
Fix the implementation of wrapping onto a new line so that it actually increments the row instead of setting it to 0

(was planning to make this later but its one line so i thought I'd just do it on my phone) 